### PR TITLE
0.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyphy-gui",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Desktop application for HyPhy",
   "main": "src/main.js",
   "repository": "https://github.com/veg/hyphy-gui",
@@ -10,7 +10,7 @@
     "bootstrap": "^4.0.0",
     "electron": "^1.8.2",
     "font-awesome": "^4.7.0",
-    "hyphy-vision": "2.1.0",
+    "hyphy-vision": "2.1.5",
     "jquery": "^3.3.1",
     "moment": "^2.22.2",
     "phylotree": "^0.1.6",

--- a/packaging.md
+++ b/packaging.md
@@ -1,6 +1,6 @@
 ### Packaging the Mac OS X Desktop Application
 
-1.  Obtain a copy of the [Electron 1.8.2 binaries](https://github.com/electron/electron/releases) (e.g. `electron-v1.8.2-darwin-x64.zip`) and decompress
+1.  Obtain a copy of the [Electron 1.8.2 binaries](https://github.com/electron/electron/releases/tag/v1.8.2) (e.g. `electron-v1.8.2-darwin-x64.zip`) and decompress
 2.  Rename the Electron binary folder and Electron binary to HyPhyGUI and HyPhyGUI.app, respectively
 3.  `cd HyPhyGUI/HyPhyGUI.app/Contents/Resources/`
 4.  `mkdir app && cd app`

--- a/yarn.lock
+++ b/yarn.lock
@@ -35,6 +35,10 @@
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@csstools/sass-import-resolve/-/sass-import-resolve-1.0.0.tgz#32c3cdb2f7af3cd8f0dca357b592e7271f3831b5"
 
+"@fortawesome/fontawesome-free@^5.3.1":
+  version "5.4.1"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-free/-/fontawesome-free-5.4.1.tgz#6194786c1a705ab84253e06429834466670e3c3f"
+
 "@types/node@^8.0.24":
   version "8.10.20"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.20.tgz#fe674ea52e13950ab10954433a7824438aabbcac"
@@ -2022,7 +2026,7 @@ cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0":
   dependencies:
     cssom "0.3.x"
 
-csvexport@^1.0.2:
+csvexport@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/csvexport/-/csvexport-1.1.0.tgz#56ddd414dd5bf874aa1fbd3f87935c27302ea881"
 
@@ -3685,20 +3689,20 @@ husky@^0.14.3:
     normalize-path "^1.0.0"
     strip-indent "^2.0.0"
 
-hyphy-vision@2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/hyphy-vision/-/hyphy-vision-2.1.0.tgz#52933225d5b5b8114a1a357775e3467b219dc0a9"
+hyphy-vision@2.1.5:
+  version "2.1.5"
+  resolved "https://registry.yarnpkg.com/hyphy-vision/-/hyphy-vision-2.1.5.tgz#9e359833903c28b0100ad165dd8bdcfa0ce81433"
   dependencies:
+    "@fortawesome/fontawesome-free" "^5.3.1"
     alignment.js "1.0.10"
     bootstrap "4.x"
     chi-squared "^1.1.0"
-    csvexport "^1.0.2"
+    csvexport "1.1.0"
     d3 "3.x"
     d3-save-svg "0.0.2"
     express "^4.16.2"
     extract-text-webpack-plugin "^2.0.0"
     file-saver "^1.3.3"
-    font-awesome "4.x"
     immutable "3.8.1"
     in-browser-download "^1.0.0"
     jquery "1.x"


### PR DESCRIPTION
Bump the version of hyphy-vision to address an issue with the csv-export button as well as incorporate additional fixes and features from vision.